### PR TITLE
Fix bower install bug on Windows 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "[WorkInProgress - ProofOfConcept] Unidirectional 1-N file syncing with history and local merging",
   "scripts": {
     "start": "./bin/filesync",
-    "postinstall": "bower install"
+    "postinstall": "./node_modules/.bin/bower install"
   },
   "bin": {
     "filesync-relay": "./bin/filesync-relay",


### PR DESCRIPTION
Fix bower install bug on Windows 8 that occurs when using 'npm i -g filesync', by using locally installed bower in the postinstall script
