### PR TITLE
Fix highlightjs error #29

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -61,9 +61,9 @@
 
   <script src="/components/angular/angular.js" type="text/javascript"></script>
   <script src="/components/angular-animate/angular-animate.js" type="text/javascript"></script>
+  <script src="/components/highlightjs/highlight.pack.js" type="text/javascript"></script>
   <script src="/components/angular-highlightjs/angular-highlightjs.js" type="text/javascript"></script>
 
-  <script src="/components/highlightjs/highlight.pack.js" type="text/javascript"></script>
   <script src="/components/moment/moment.js" type="text/javascript"></script>
   <script src="/components/lodash/lodash.js" type="text/javascript"></script>
   <script src="/components/visibilityjs/lib/visibility.core.js" type="text/javascript"></script>


### PR DESCRIPTION
After some "console.log" inside highlightjs' dependencies I found how to solve the problem (issue #29) : _highlight.pack.js_ must be loaded before _angular-highlightjs.js_
